### PR TITLE
Fix: Correctly hide Matplotlib toolbar in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,8 +87,8 @@ else:
     print("Error")
     help()
 
+plt.rcParams['toolbar'] = 'None'
 fig, ax = plt.subplots()
-fig.canvas.toolbar.pack_forget()
 container = ax.bar(np.arange(0, len(sorted_arr), 1), sorted_arr, align="edge", width=0.8)
 ax.set(xlabel="Index", ylabel="Value", title=sorter)
 txt = ax.text(0, 1000, "")


### PR DESCRIPTION
Replaced the erroneous call to `fig.canvas.toolbar.pack_forget()`, which was causing an AttributeError because `NavigationToolbar2QT` does not have this method.

The toolbar is now hidden by setting the Matplotlib rcParam `toolbar` to `'None'` before the figure is created. This is the standard way to disable the toolbar.

This resolves the AttributeError encountered when running the script with arguments like "insertion".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Changed the method for disabling the matplotlib toolbar to use a global configuration setting, ensuring the toolbar is hidden for all plots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->